### PR TITLE
Add basic change events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # datalive
 Living JSON file
+
+## Events
+
+Instances emit `change` and `delete` events whenever a top-level key is
+modified.  Listen for a specific key using `change:<key>` or for all changes
+with the generic `change` event.

--- a/index.js
+++ b/index.js
@@ -108,6 +108,7 @@ export default class DataLive extends EventEmitter {
   }
 
   #proxyFactory(root) {
+    const self = this
     const write = () => this.#write(root);
 
     const handler = {
@@ -119,14 +120,14 @@ export default class DataLive extends EventEmitter {
         const ok = Reflect.set(target, prop, value);
         write()
         if (this.verbose) console.log('DataLive- set', prop, value)
-        this.#emitChange(prop, value)
+        self.#emitChange(prop, value)
         return ok;
       },
       deleteProperty(target, prop) {
         const ok = Reflect.deleteProperty(target, prop);
         write()
         if (this.verbose) console.log('DataLive- deleted', prop)
-        this.#emitDelete(prop)
+        self.#emitDelete(prop)
         return ok;
       },
     };

--- a/index.test.js
+++ b/index.test.js
@@ -193,3 +193,33 @@ describe('DataLive default temporary file', () => {
     fs.unlinkSync(DL.filepath)
   })
 })
+
+describe('DataLive events', () => {
+  let file, DL, dl
+
+  beforeEach(() => {
+    file = path.join(tmpdir(), `${Math.random()}.json`)
+    fs.writeFileSync(file, JSON.stringify({}, replacer))
+    DL = new DataLive(file, {verbose: false})
+    dl = DL.live()
+  })
+
+  afterEach(() => fs.rmSync(file, {force: true}))
+
+  it('emits change events for keys', () => {
+    let value
+    DL.on('change:test', v => value = v)
+    dl.test = 'hello'
+    expect(value).toBe('hello')
+  })
+
+  it('emits events when file changes', async () => {
+    let captured
+    DL.on('change:test', v => captured = v)
+    const json = JSON.parse(fs.readFileSync(file, 'utf8'), reviver)
+    json.test = 'world'
+    fs.writeFileSync(file, JSON.stringify(json, replacer))
+    await sleep(100)
+    expect(captured).toBe('world')
+  })
+})


### PR DESCRIPTION
## Summary
- emit events when keys are changed or deleted
- watch for on-disk changes and emit matching events
- document the new events
- test event emitter behaviour

## Testing
- `npm test --silent` *(fails: vitest not found)*